### PR TITLE
feat: deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 go-ipfs-addr
 ==================
 
+**DEPRECATED**
+
+This package was introduced at a time when multiaddr didn't support "ipfs" (or libp2p) addresses. Please use [`SplitAddr`](https://godoc.org/github.com/libp2p/go-libp2p-core/peer#SplitAddr) and [`AddrInfoFromP2pAddrs`](https://godoc.org/github.com/libp2p/go-libp2p-core/peer#AddrInfoFromP2pAddr) from `github.com/libp2p/go-libp2p-peer`.
+
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)


### PR DESCRIPTION
Given that "ipfs" addresses are now "libp2p" addresses, all relevant functionality has been moved to github.com/libp2p/go-libp2p-core/peer.

fixes #6